### PR TITLE
Test

### DIFF
--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -8,7 +8,7 @@ example usage:
 '''
 
 import argparse
-import threading
+import multiprocessing
 
 import pync
 
@@ -39,9 +39,9 @@ def main():
             stdin=pync.PIPE,
             stdout=pync.PIPE,
     )
-    t = threading.Thread(target=server.readwrite)
-    t.daemon = True
-    t.start()
+    p = multiprocessing.Process(target=server.readwrite)
+    p.daemon = True
+    p.start()
 
     client = pync.Netcat(args.dest, args.port,
             v=True,

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -278,6 +278,17 @@ class NetcatContext(object):
             self._stdout = self.stdout
             self.stdout = None
 
+        if self.stderr == PIPE:
+            pipe = NetcatPipe()
+            self._stderr = pipe.writer
+            self.stderr = pipe.reading
+        elif self.stderr == STDOUT:
+            self._stderr = self._stdout
+            self.stderr = self.stdout
+        else:
+            self._stderr = self.stderr
+            self.stderr = None
+
         self._init_kwargs(**kwargs)
 
     def _init_kwargs(self, **kwargs):

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -323,11 +323,11 @@ class NetcatContext(object):
 
     def print_verbose(self, message):
         if self.v:
-            self._print_message(message, file=self.stderr)
+            self._print_message(message, file=self._stderr)
 
     def print_debug(self, message):
         if self.D:
-            self._print_message(message, file=self.stderr)
+            self._print_message(message, file=self._stderr)
 
 
 class NetcatConnection(NetcatContext):

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -255,9 +255,9 @@ class NetcatConsoleWriter(NetcatFileWriter):
 class NetcatContext(object):
     D = False
     v = False
-    stdin = STDIN
-    stdout = STDOUT
-    stderr = STDERR
+    stdin = sys.stdin
+    stdout = sys.stdout
+    stderr = sys.stderr
 
     def __init__(self,
             D=None,
@@ -275,50 +275,32 @@ class NetcatContext(object):
 
         if self.stdin == PIPE:
             pipe = NetcatPipe()
-            self.__stdin = pipe.reader
+            self._stdin = pipe.reader
             self.stdin = pipe.writer
         else:
-            self.__stdin = self.stdin
+            self._stdin = self.stdin
             self.stdin = None
 
         if self.stdout == PIPE:
             pipe = NetcatPipe()
-            self.__stdout = pipe.writer
+            self._stdout = pipe.writer
             self.stdout = pipe.reader
         else:
-            self.__stdout = self.stdout
+            self._stdout = self.stdout
             self.stdout = None
 
         if self.stderr == PIPE:
             pipe = NetcatPipe()
-            self.__stderr = pipe.writer
+            self._stderr = pipe.writer
             self.stderr = pipe.reader
         elif self.stderr == STDOUT:
-            self.__stderr = self._stdout
+            self._stderr = self._stdout
             self.stderr = self.stdout
         else:
-            self.__stderr = self.stderr
+            self._stderr = self.stderr
             self.stderr = None
 
         self._init_kwargs(**kwargs)
-
-    @property
-    def _stdin(self):
-        if self.__stdin == STDIN:
-            return sys.stdin
-        return self.__stdin
-
-    @property
-    def _stdout(self):
-        if self.__stdout == STDOUT:
-            return sys.stdout
-        return self.__stdout
-
-    @property
-    def _stderr(self):
-        if self.__stderr == STDERR:
-            return sys.stderr
-        return self.__stderr
 
     def _init_kwargs(self, **kwargs):
         """
@@ -2007,9 +1989,9 @@ class Netcat(object):
     UDPClient = NetcatUDPClient
     UDPServer = NetcatUDPServer
 
-    stdin = STDIN
-    stdout = STDOUT
-    stderr = STDERR
+    stdin = sys.stdin
+    stdout = sys.stdout
+    stderr = sys.stderr
 
     def __new__(cls, dest='', port=None, l=False, u=False, p=None,
             stdin=None, stdout=None, stderr=None, **kwargs):
@@ -2140,13 +2122,6 @@ def pync(args, stdin=None, stdout=None, stderr=None, Netcat=Netcat):
     _stdin = stdin or Netcat.stdin
     _stdout = stdout or Netcat.stdout
     _stderr = stderr or Netcat.stderr
-
-    if _stdin == STDIN:
-        _stdin = sys.stdin
-    if _stdout == STDOUT:
-        _stdout = sys.stdout
-    if _stderr == STDERR:
-        _stderr = sys.stderr
 
     exit = argparse.Namespace()
     exit.status = 1

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -118,6 +118,15 @@ class NetcatPipeIO(object):
     def fileno(self):
         return self._conn.fileno()
 
+    def read(self, n):
+        raise NotImplementedError
+
+    def write(self, data):
+        raise NotImplementedError
+
+    def flush(self):
+        pass
+
 
 class NetcatPipeReader(NetcatPipeIO):
 

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -557,16 +557,6 @@ class NetcatConnection(NetcatContext):
         net_send, net_recv = self.send, self.recv
         net_shutdown_rd, net_shutdown_wr = self.shutdown_rd, self.shutdown_wr
 
-        #try:
-        #    stdin_read = self._stdin.buffer.read
-        #except AttributeError:
-        #    stdin_read = self._stdin.read
-
-        #try:
-        #    stdout_write = self._stdout.buffer.write
-        #except AttributeError:
-        #    stdout_write = self._stdout.write
-
         stdin_detach = self.d
         stdin_read = self._stdin.read
         stdout_write = self._stdout.write

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -112,6 +112,39 @@ class NetcatProxyError(NetcatError):
         self.proxy_err =  proxy_err
 
 
+class NetcatStdinReader(object):
+
+    def fileno(self):
+        return sys.stdin.fileno()
+
+    def read(self, n):
+        return sys.stdin.read(n)
+
+
+class NetcatStdoutWriter(object):
+
+    def fileno(self):
+        return sys.stdout.fileno()
+
+    def write(self, data):
+        sys.stdout.write(data)
+
+    def flush(self):
+        sys.stdout.flush()
+
+
+class NetcatStderrWriter(object):
+
+    def fileno(self):
+        return sys.stderr.fileno()
+
+    def write(self, data):
+        sys.stderr.write(data)
+
+    def flush(self):
+        sys.stderr.flush()
+
+
 class NetcatPipeIO(object):
 
     def __init__(self, conn):
@@ -273,7 +306,10 @@ class NetcatContext(object):
         self.stdout = stdout or self.stdout
         self.stderr = stderr or self.stderr
 
-        if self.stdin == PIPE:
+        if self.stdin is sys.stdin:
+            self._stdin = NetcatStdinReader()
+            self.stdin = None
+        elif self.stdin == PIPE:
             pipe = NetcatPipe()
             self._stdin = pipe.reader
             self.stdin = pipe.writer
@@ -281,7 +317,10 @@ class NetcatContext(object):
             self._stdin = self.stdin
             self.stdin = None
 
-        if self.stdout == PIPE:
+        if self.stdout is sys.stdout:
+            self._stdout = NetcatStdoutWriter()
+            self.stdout = None
+        elif self.stdout == PIPE:
             pipe = NetcatPipe()
             self._stdout = pipe.writer
             self.stdout = pipe.reader
@@ -289,7 +328,10 @@ class NetcatContext(object):
             self._stdout = self.stdout
             self.stdout = None
 
-        if self.stderr == PIPE:
+        if self.stderr is sys.stderr:
+            self._stderr = NetcatStderrWriter()
+            self.stderr = None
+        elif self.stderr == PIPE:
             pipe = NetcatPipe()
             self._stderr = pipe.writer
             self.stderr = pipe.reader

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -314,7 +314,7 @@ class NetcatContext(object):
     def _print_message(self, message, file=None):
         if message:
             if file is None:
-                file = self.stderr
+                file = self._stderr
             try:
                 file.write(message+'\n')
             except TypeError:

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -290,7 +290,7 @@ class NetcatContext(object):
         if self.stderr == PIPE:
             pipe = NetcatPipe()
             self._stderr = pipe.writer
-            self.stderr = pipe.reading
+            self.stderr = pipe.reader
         elif self.stderr == STDOUT:
             self._stderr = self._stdout
             self.stderr = self.stdout

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -75,8 +75,6 @@ TOSKEYWORDS = dict(
 
 PIPE = subprocess.PIPE
 STDOUT = subprocess.STDOUT
-STDIN = -3
-STDERR = -4
 
 
 def _debug(s):
@@ -114,35 +112,29 @@ class NetcatProxyError(NetcatError):
 
 class NetcatStdinReader(object):
 
-    def fileno(self):
-        return sys.stdin.fileno()
+    def __getattr__(self, name):
+        return getattr(sys.stdin, name)
 
-    def read(self, n):
-        return sys.stdin.read(n)
+    def __eq__(self, other):
+        return other == sys.stdin
 
 
 class NetcatStdoutWriter(object):
 
-    def fileno(self):
-        return sys.stdout.fileno()
+    def __getattr__(self, name):
+        return getattr(sys.stdout, name)
 
-    def write(self, data):
-        sys.stdout.write(data)
-
-    def flush(self):
-        sys.stdout.flush()
+    def __eq__(self, other):
+        return other == sys.stdout
 
 
 class NetcatStderrWriter(object):
 
-    def fileno(self):
-        return sys.stderr.fileno()
+    def __getattr__(self, name):
+        return getattr(sys.stderr, name)
 
-    def write(self, data):
-        sys.stderr.write(data)
-
-    def flush(self):
-        sys.stderr.flush()
+    def __eq__(self, other):
+        return other == sys.stderr
 
 
 class NetcatPipeIO(object):
@@ -430,12 +422,12 @@ class NetcatConnection(NetcatContext):
         if w is not None:
             self.w = w
 
-        if self._stdin is sys.__stdin__ and self._stdin.isatty():
+        if self._stdin == sys.stdin and self._stdin.isatty():
             self._stdin = NetcatConsoleInput()
         else:
             self._stdin = NetcatFileReader(self._stdin)
 
-        if self._stdout is sys.__stdout__:
+        if self._stdout == sys.stdout:
             self._stdout = NetcatConsoleWriter()
         else:
             self._stdout = NetcatFileWriter(self._stdout)


### PR DESCRIPTION
Netcat classes no longer directly store the sys.stdin/out/err file handles.
Created delegate classes NetcatStdinReader, NetcatStdoutWriter and NetcatStderrWriter instead.
This is to prevent multiprocessing.Process from throwing an error when trying to pickle the file handles.