### PR TITLE
Refactor

### DIFF
--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -376,6 +376,7 @@ class NetcatContext(object):
         else:
             self._stdout = self.stdout
             self.stdout = None
+        self._stdout = NetcatFileWriter(self._stdout)
 
         if self.stderr is sys.stderr:
             self._stderr = NetcatStderrWriter()
@@ -394,6 +395,11 @@ class NetcatContext(object):
         else:
             self._stderr = self.stderr
             self.stderr = None
+
+        if self._stdin == sys.stdin and self._stdin.isatty():
+            self._stdin = NetcatConsoleInput()
+        else:
+            self._stdin = NetcatFileReader(self._stdin)
 
         self._init_kwargs(**kwargs)
 
@@ -482,16 +488,6 @@ class NetcatConnection(NetcatContext):
             self.q = q
         if w is not None:
             self.w = w
-
-        if self._stdin == sys.stdin and self._stdin.isatty():
-            self._stdin = NetcatConsoleInput()
-        else:
-            self._stdin = NetcatFileReader(self._stdin)
-
-        if self._stdout == sys.stdout:
-            self._stdout = NetcatConsoleWriter()
-        else:
-            self._stdout = NetcatFileWriter(self._stdout)
 
     @classmethod
     def connect(cls, dest, port, **kwargs):

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -685,6 +685,7 @@ class NetcatConnection(NetcatContext):
                     last_io, sleep = time_now(), False
                 elif net_data is not None:
                     # netin EOF
+                    stdout_write(b'')
                     net_shutdown_rd()
                     netin_eof = True
 

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -347,8 +347,11 @@ class NetcatContext(object):
         self.stdout = stdout or self.stdout
         self.stderr = stderr or self.stderr
 
-        if self.stdin is sys.stdin and self.stdin.isatty():
-            self._stdin = NetcatConsoleInput()
+        if self.stdin is sys.stdin:
+            if self.stdin.isatty():
+                self._stdin = NetcatConsoleInput()
+            else:
+                self._stdin = NetcatFileReader(NetcatStdinReader())
             self.stdin = None
         elif self.stdin == PIPE:
             pipe = NetcatPipe()
@@ -363,7 +366,7 @@ class NetcatContext(object):
             self.stdin = None
 
         if self.stdout is sys.stdout:
-            self._stdout = NetcatStdoutWriter()
+            self._stdout = NetcatFileWriter(NetcatStdoutWriter())
             self.stdout = None
         elif self.stdout == PIPE:
             pipe = NetcatPipe()
@@ -378,7 +381,7 @@ class NetcatContext(object):
             self.stdout = None
 
         if self.stderr is sys.stderr:
-            self._stderr = NetcatStderrWriter()
+            self._stderr = NetcatFileWriter(NetcatStderrWriter())
             self.stderr = None
         elif self.stderr == PIPE:
             pipe = NetcatPipe()

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -347,8 +347,8 @@ class NetcatContext(object):
         self.stdout = stdout or self.stdout
         self.stderr = stderr or self.stderr
 
-        if self.stdin is sys.stdin:
-            self._stdin = NetcatStdinReader()
+        if self.stdin is sys.stdin and self.stdin.isatty():
+            self._stdin = NetcatConsoleInput()
             self.stdin = None
         elif self.stdin == PIPE:
             pipe = NetcatPipe()
@@ -359,7 +359,7 @@ class NetcatContext(object):
             self._stdin = q.reader
             self.stdin = q.writer
         else:
-            self._stdin = self.stdin
+            self._stdin = NetcatFileReader(self.stdin)
             self.stdin = None
 
         if self.stdout is sys.stdout:
@@ -374,9 +374,8 @@ class NetcatContext(object):
             self._stdout = q.writer
             self.stdout = q.reader
         else:
-            self._stdout = self.stdout
+            self._stdout = NetcatFileWriter(self.stdout)
             self.stdout = None
-        self._stdout = NetcatFileWriter(self._stdout)
 
         if self.stderr is sys.stderr:
             self._stderr = NetcatStderrWriter()
@@ -393,13 +392,8 @@ class NetcatContext(object):
             self._stderr = self._stdout
             self.stderr = self.stdout
         else:
-            self._stderr = self.stderr
+            self._stderr = NetcatFileWriter(self.stderr)
             self.stderr = None
-
-        if self._stdin == sys.stdin and self._stdin.isatty():
-            self._stdin = NetcatConsoleInput()
-        else:
-            self._stdin = NetcatFileReader(self._stdin)
 
         self._init_kwargs(**kwargs)
 


### PR DESCRIPTION
* refactor NetcatReader/Writer classes and NetcatContext.__init__
* Write empty string (b'') to stdout when net connection lost.
  This is to let whatever is reading stdout know that the connection was lost.