### PR TITLE
Pipe refactor2

### DIFF
--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -8,7 +8,7 @@ example usage:
 '''
 
 import argparse
-import multiprocessing
+import contextlib
 
 import pync
 
@@ -39,9 +39,7 @@ def main():
             stdin=pync.PIPE,
             stdout=pync.PIPE,
     )
-    p = multiprocessing.Process(target=server.readwrite)
-    p.daemon = True
-    p.start()
+    server.start(daemon=True)
 
     client = pync.Netcat(args.dest, args.port,
             v=True,
@@ -49,11 +47,8 @@ def main():
             stdout=server.stdin,
     )
 
-    try:
+    with contextlib.closing(client):
         client.readwrite()
-    finally:
-        client.close()
-        server.close()
 
 
 if __name__ == '__main__':

--- a/src/pync/conin.py
+++ b/src/pync/conin.py
@@ -23,7 +23,6 @@ class _WinConsoleInput(_BaseConsoleInput):
     def __init__(self, *args, **kwargs):
         super(_WinConsoleInput, self).__init__(*args, **kwargs)
         self.line = b''
-        self._stdout = sys.__stdout__
     
     def readline(self):
         # Non-blocking console input for Windows.
@@ -55,17 +54,13 @@ class _WinConsoleInput(_BaseConsoleInput):
 
     def _stdout_write(self, data):
         try:
-            self._stdout.buffer.write(data)
+            sys.stdout.buffer.write(data)
         except AttributeError:
-            self._stdout.write(data)
-        self._stdout.flush()
+            sys.stdout.write(data)
+        sys.stdout.flush()
 
 
 class _UnixConsoleInput(_BaseConsoleInput):
-
-    def __init__(self, *args, **kwargs):
-        super(_UnixConsoleInput, self).__init__(*args, **kwargs)
-        #self._stdin = sys.__stdin__
 
     def readline(self):
         # Non-blocking console input for *nix.

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -515,12 +515,19 @@ class NetcatContext(object):
         self.close()
 
     def start(self, daemon=False):
-        p = multiprocessing.Process(target=self.readwrite)
+        def readwrite():
+            try:
+                self.readwrite()
+            finally:
+                self.close()
+
+        p = multiprocessing.Process(target=readwrite)
         if daemon:
             p.daemon = True
         p.start()
         if isinstance(self._stdout, NetcatPipeWriter):
             self._stdout.close()
+        return p
 
     def close(self):
         """

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -398,12 +398,12 @@ class NetcatConsoleWriter(NetcatFileWriter):
 class NetcatContext(object):
     D = False
     v = False
-    #stdin = sys.stdin
-    #stdout = sys.stdout
-    #stderr = sys.stderr
-    stdin = None
-    stdout = None
-    stderr = None
+    stdin = sys.stdin
+    stdout = sys.stdout
+    stderr = sys.stderr
+    #stdin = None
+    #stdout = None
+    #stderr = None
 
     def __init__(self,
             D=None,
@@ -425,12 +425,12 @@ class NetcatContext(object):
         elif isinstance(self.stdin, NetcatIOBase):
             self._stdin = self.stdin
             self.stdin = None
-        elif self.stdin is None:
-            if sys.stdin.isatty():
+        elif self.stdin is sys.stdin:
+            if self.stdin.isatty():
                 self._stdin = NetcatConsoleInput()
             else:
                 self._stdin = NetcatFileReader(NetcatStdinReader())
-            #self.stdin = None
+            self.stdin = None
         elif self.stdin == PIPE:
             pipe = NetcatPipeIO()
             self._stdin = pipe.reader
@@ -449,9 +449,9 @@ class NetcatContext(object):
         elif isinstance(self.stdout, NetcatIOBase):
             self._stdout = self.stdout
             self.stdout = None
-        elif self.stdout is None:
+        elif self.stdout is sys.stdout:
             self._stdout = NetcatFileWriter(NetcatStdoutWriter())
-            #self.stdout = None
+            self.stdout = None
         elif self.stdout == PIPE:
             pipe = NetcatPipeIO()
             self._stdout = pipe.writer
@@ -470,9 +470,9 @@ class NetcatContext(object):
         if isinstance(self.stderr, NetcatIOBase):
             self._stderr = self.stderr
             self.stderr = None
-        elif self.stderr is None:
+        elif self.stderr is sys.stderr:
             self._stderr = NetcatFileWriter(NetcatStderrWriter())
-            #self.stderr = None
+            self.stderr = None
         elif self.stderr == PIPE:
             pipe = NetcatPipeIO()
             self._stderr = pipe.writer
@@ -2172,12 +2172,12 @@ class Netcat(object):
     UDPClient = NetcatUDPClient
     UDPServer = NetcatUDPServer
 
-    #stdin = sys.stdin
-    #stdout = sys.stdout
-    #stderr = sys.stderr
-    stdin = None
-    stdout = None
-    stderr = None
+    stdin = sys.stdin
+    stdout = sys.stdout
+    stderr = sys.stderr
+    #stdin = None
+    #stdout = None
+    #stderr = None
 
     def __new__(cls, dest='', port=None, l=False, u=False, p=None,
             stdin=None, stdout=None, stderr=None, **kwargs):

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -209,6 +209,9 @@ class NetcatPipeIOBase(NetcatIOBase):
     def recv_bytes(self):
         raise io.UnsupportedOperation
 
+    def close(self):
+        os.close(self.fileno())
+
 
 class NetcatPipeReader(NetcatPipeIOBase):
 
@@ -230,6 +233,8 @@ class NetcatPipeWriter(NetcatPipeIOBase):
 
     def write(self, data):
         self.send_bytes(data)
+        if not data:
+            self.close()
 
 
 class NetcatPipeIO(NetcatIO):

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -232,10 +232,9 @@ class NetcatPipeWriter(NetcatPipeIOBase):
         return self.connection.send_bytes(data)
 
     def write(self, data):
+        self.send_bytes(data)
         if not data:
             self.close()
-            return
-        self.send_bytes(data)
 
 
 class NetcatPipeIO(NetcatIO):

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -96,6 +96,14 @@ def _debug(s):
     sys.__stderr__.flush()
 
 
+def _readwrite_close(nc):
+    # For NetcatContext().start() method.
+    try:
+        nc.readwrite()
+    finally:
+        nc.close()
+
+
 class NetcatError(Exception):
     
     def __init__(self, msg, *args):
@@ -515,13 +523,10 @@ class NetcatContext(object):
         self.close()
 
     def start(self, daemon=False):
-        def readwrite():
-            try:
-                self.readwrite()
-            finally:
-                self.close()
-
-        p = multiprocessing.Process(target=readwrite)
+        p = multiprocessing.Process(
+                target=_readwrite_close,
+                args=(self,)
+        )
         if daemon:
             p.daemon = True
         p.start()

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -24,9 +24,9 @@ import time
 
 try:
     import msvcrt
-    _windows = True
+    _mswindows = True
 except ImportError:
-    _windows = False
+    _mswindows = False
 
 try:
     # py2
@@ -193,7 +193,7 @@ class NetcatPipeIOBase(NetcatIOBase):
     def __init__(self, conn):
         self.connection = conn
         self._fileno = self.connection.fileno()
-        if _windows:
+        if _mswindows:
             self._fileno = msvcrt.open_osfhandle(self._fileno, os.O_TEXT)
         super(NetcatPipeIOBase, self).__init__()
 
@@ -401,9 +401,6 @@ class NetcatContext(object):
     stdin = sys.stdin
     stdout = sys.stdout
     stderr = sys.stderr
-    #stdin = None
-    #stdout = None
-    #stderr = None
 
     def __init__(self,
             D=None,

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -244,8 +244,8 @@ class NetcatPipeIO(NetcatIO):
 
     def __init__(self):
         recv_conn, send_conn = multiprocessing.Pipe(False)
-        reader = self.Reader(recv_conn, self)
-        writer = self.Writer(send_conn, self)
+        reader = self.Reader(recv_conn)
+        writer = self.Writer(send_conn)
         super(NetcatPipeIO, self).__init__(reader, writer)
 
 

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -210,7 +210,7 @@ class NetcatPipeIOBase(NetcatIOBase):
         raise io.UnsupportedOperation
 
     def close(self):
-        os.close(self.fileno())
+        self.connection.close()
 
 
 class NetcatPipeReader(NetcatPipeIOBase):
@@ -232,9 +232,10 @@ class NetcatPipeWriter(NetcatPipeIOBase):
         return self.connection.send_bytes(data)
 
     def write(self, data):
-        self.send_bytes(data)
         if not data:
             self.close()
+            return
+        self.send_bytes(data)
 
 
 class NetcatPipeIO(NetcatIO):
@@ -243,8 +244,8 @@ class NetcatPipeIO(NetcatIO):
 
     def __init__(self):
         recv_conn, send_conn = multiprocessing.Pipe(False)
-        reader = self.Reader(recv_conn)
-        writer = self.Writer(send_conn)
+        reader = self.Reader(recv_conn, self)
+        writer = self.Writer(send_conn, self)
         super(NetcatPipeIO, self).__init__(reader, writer)
 
 

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -514,6 +514,14 @@ class NetcatContext(object):
     def __exit__(self, *args, **kwargs):
         self.close()
 
+    def start(self, daemon=False):
+        p = multiprocessing.Process(target=self.readwrite)
+        if daemon:
+            p.daemon = True
+        p.start()
+        if isinstance(self._stdout, NetcatPipeWriter):
+            self._stdout.close()
+
     def close(self):
         """
         Override to add any cleanup code.

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -398,9 +398,12 @@ class NetcatConsoleWriter(NetcatFileWriter):
 class NetcatContext(object):
     D = False
     v = False
-    stdin = sys.stdin
-    stdout = sys.stdout
-    stderr = sys.stderr
+    #stdin = sys.stdin
+    #stdout = sys.stdout
+    #stderr = sys.stderr
+    stdin = None
+    stdout = None
+    stderr = None
 
     def __init__(self,
             D=None,
@@ -422,12 +425,12 @@ class NetcatContext(object):
         elif isinstance(self.stdin, NetcatIOBase):
             self._stdin = self.stdin
             self.stdin = None
-        elif self.stdin is sys.stdin:
-            if self.stdin.isatty():
+        elif self.stdin is None:
+            if sys.stdin.isatty():
                 self._stdin = NetcatConsoleInput()
             else:
                 self._stdin = NetcatFileReader(NetcatStdinReader())
-            self.stdin = None
+            #self.stdin = None
         elif self.stdin == PIPE:
             pipe = NetcatPipeIO()
             self._stdin = pipe.reader
@@ -446,9 +449,9 @@ class NetcatContext(object):
         elif isinstance(self.stdout, NetcatIOBase):
             self._stdout = self.stdout
             self.stdout = None
-        elif self.stdout is sys.stdout:
+        elif self.stdout is None:
             self._stdout = NetcatFileWriter(NetcatStdoutWriter())
-            self.stdout = None
+            #self.stdout = None
         elif self.stdout == PIPE:
             pipe = NetcatPipeIO()
             self._stdout = pipe.writer
@@ -467,9 +470,9 @@ class NetcatContext(object):
         if isinstance(self.stderr, NetcatIOBase):
             self._stderr = self.stderr
             self.stderr = None
-        elif self.stderr is sys.stderr:
+        elif self.stderr is None:
             self._stderr = NetcatFileWriter(NetcatStderrWriter())
-            self.stderr = None
+            #self.stderr = None
         elif self.stderr == PIPE:
             pipe = NetcatPipeIO()
             self._stderr = pipe.writer
@@ -2169,9 +2172,12 @@ class Netcat(object):
     UDPClient = NetcatUDPClient
     UDPServer = NetcatUDPServer
 
-    stdin = sys.stdin
-    stdout = sys.stdout
-    stderr = sys.stderr
+    #stdin = sys.stdin
+    #stdout = sys.stdout
+    #stderr = sys.stderr
+    stdin = None
+    stdout = None
+    stderr = None
 
     def __new__(cls, dest='', port=None, l=False, u=False, p=None,
             stdin=None, stdout=None, stderr=None, **kwargs):

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -761,7 +761,10 @@ class NetcatConnection(NetcatContext):
 
                 # stdin
                 if not stdin_detach:
-                    stdin_data = stdin_read(plen)
+                    try:
+                        stdin_data = stdin_read(plen)
+                    except EOFError:
+                        stdin_data = b''
 
                     # netout
                     if stdin_data:

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -192,12 +192,13 @@ class NetcatPipeIOBase(NetcatIOBase):
 
     def __init__(self, conn):
         self.connection = conn
+        self._fileno = self.connection.fileno()
+        if _windows:
+            self._fileno = msvcrt.open_osfhandle(self._fileno, os.O_TEXT)
         super(NetcatPipeIOBase, self).__init__()
 
     def fileno(self):
-        if _windows:
-            return msvcrt.open_osfhandle(self.connection.fileno())
-        return self.connection.fileno()
+        return self._fileno
     
     def poll(self):
         raise io.UnsupportedOperation

--- a/src/pync/netcat.py
+++ b/src/pync/netcat.py
@@ -23,6 +23,12 @@ import sys
 import time
 
 try:
+    import msvcrt
+    _windows = True
+except ImportError:
+    _windows = False
+
+try:
     # py2
     import Queue as queue
 except ImportError:
@@ -189,6 +195,8 @@ class NetcatPipeIOBase(NetcatIOBase):
         super(NetcatPipeIOBase, self).__init__()
 
     def fileno(self):
+        if _windows:
+            return msvcrt.open_osfhandle(self.connection.fileno())
         return self.connection.fileno()
     
     def poll(self):


### PR DESCRIPTION
* Pipe refactor to allow piping input and output between processes.
* Added NetcatContext().start() method to start a netcat instance in a separate process.